### PR TITLE
chore: babel-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,9 +1297,9 @@
       }
     },
     "babel-loader": {
-      "version": "8.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0-beta.4.tgz",
-      "integrity": "sha512-fQMCj8jRpF/2CPuVnpFrOb8+8pRuquKqoC+tspy5RWBmL37/2qc104sLLLqpwWltrFzpYb30utPpKc3H6P3ETQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
+      "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/core": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
     "@babel/preset-react": "^7.0.0-beta.54",
-    "babel-loader": "^8.0.0-beta.4",
+    "babel-loader": "^8.0.4",
     "css-loader": "^1.0.0",
     "eslint": "^5.6.1",
     "eslint-config-airbnb": "^17.1.0",


### PR DESCRIPTION
Update `babel-loader` from `8.0.0-beta.4` to `8.0.4`

fix #31